### PR TITLE
Fix API for Global State Change (XUserRest) & Get Groups info from cache. (Atlas Plugin)

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/service/RangerBasePlugin.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/service/RangerBasePlugin.java
@@ -67,6 +67,7 @@ public class RangerBasePlugin {
 	private       RangerAuthContext           currentAuthContext;
 	private       RangerAccessResultProcessor resultProcessor;
 	private       RangerRoles                 roles;
+	private       RangerUserStore             userStore;
 	private final List<RangerChainedPlugin>   chainedPlugins;
 
 
@@ -166,6 +167,22 @@ public class RangerBasePlugin {
 		}
 
 		pluginContext.notifyAuthContextChanged();
+	}
+
+	public RangerUserStore getUserStore() {
+		return this.userStore;
+	}
+
+	public void setUserStore(RangerUserStore userStore) {
+		this.userStore = userStore;
+
+		// RangerPolicyEngine policyEngine = this.policyEngine;
+
+		// if (policyEngine != null) {
+		// 	policyEngine.setUserStore(userStore);
+		// }
+
+		// pluginContext.notifyAuthContextChanged();
 	}
 
 	public void setAuditExcludedUsersGroupsRoles(Set<String> users, Set<String> groups, Set<String> roles) {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTUtils.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRESTUtils.java
@@ -74,6 +74,7 @@ public class RangerRESTUtils {
 
 	public static final String REST_PARAM_LAST_KNOWN_USERSTORE_VERSION = "lastKnownUserStoreVersion";
 	public static final String REST_URL_SERVICE_SERCURE_GET_USERSTORE = "/service/xusers/secure/download/";
+	public static final String REST_URL_SERVICE_GET_USERSTORE = "/service/xusers/download/";
 
 	private static final int MAX_PLUGIN_ID_LEN = 255;
 	

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerUserStore.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerUserStore.java
@@ -53,6 +53,7 @@ public class RangerUserStore implements Serializable {
     private Map<String, Set<String>>         userGroupMapping;
     private Map<String, String>              userCloudIdMapping;
     private Map<String, String>              groupCloudIdMapping;
+    private String                           serviceName;
 
     public RangerUserStore() {this(-1L, null, null, null);}
 
@@ -62,6 +63,15 @@ public class RangerUserStore implements Serializable {
         setUserGroupMapping(userGroups);
         buildMap(users, groups);
     }
+    
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+    
     public Long getUserStoreVersion() {
         return userStoreVersion;
     }

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerUserStoreProvider.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerUserStoreProvider.java
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.util;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.ranger.admin.client.RangerAdminClient;
+import org.apache.ranger.plugin.service.RangerBasePlugin;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Set;
+
+
+public class RangerUserStoreProvider {
+	private static final Log LOG = LogFactory.getLog(RangerUserStoreProvider.class);
+
+	private static final Log PERF_POLICYENGINE_INIT_LOG = RangerPerfTracer.getPerfLogger("policyengine.init");
+
+	private final String            serviceType;
+	private final String            serviceName;
+	private final RangerAdminClient rangerAdmin;
+
+	private final String            cacheFileName;
+	private final String			cacheFileNamePrefix;
+	private final String            cacheDir;
+	private final Gson              gson;
+	private final boolean           disableCacheIfServiceNotFound;
+
+	private long	lastActivationTimeInMillis;
+	private long    lastKnownUserStoreVersion = -1L;
+	private boolean rangerUserStoreSetInPlugin;
+	private boolean serviceDefSetInPlugin;
+
+	public RangerUserStoreProvider(String serviceType, String appId, String serviceName, RangerAdminClient rangerAdmin, String cacheDir, Configuration config) {
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("==> RangerUserStoreProvider(serviceName=" + serviceName + ").RangerUserStoreProvider()");
+		}
+
+		this.serviceType = serviceType;
+		this.serviceName = serviceName;
+		this.rangerAdmin = rangerAdmin;
+
+
+		if (StringUtils.isEmpty(appId)) {
+			appId = serviceType;
+		}
+
+		cacheFileNamePrefix = "userstore";
+		String cacheFilename = String.format("%s_%s_%s.json", appId, serviceName, cacheFileNamePrefix);
+		cacheFilename = cacheFilename.replace(File.separatorChar, '_');
+		cacheFilename = cacheFilename.replace(File.pathSeparatorChar, '_');
+
+		this.cacheFileName = cacheFilename;
+		this.cacheDir = cacheDir;
+
+		Gson gson = null;
+		try {
+			gson = new GsonBuilder().setDateFormat("yyyyMMdd-HH:mm:ss.SSS-Z").create();
+		} catch (Throwable excp) {
+			LOG.fatal("RangerUserStoreProvider(): failed to create GsonBuilder object", excp);
+		}
+		this.gson = gson;
+
+		String propertyPrefix = "ranger.plugin." + serviceType;
+		disableCacheIfServiceNotFound = config.getBoolean(propertyPrefix + ".disable.cache.if.servicenotfound", true);
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("<== RangerUserStoreProvider(serviceName=" + serviceName + ").RangerUserStoreProvider()");
+		}
+	}
+
+	public long getLastActivationTimeInMillis() {
+		return lastActivationTimeInMillis;
+	}
+
+	public void setLastActivationTimeInMillis(long lastActivationTimeInMillis) {
+		this.lastActivationTimeInMillis = lastActivationTimeInMillis;
+	}
+
+	public void loadUserStore(RangerBasePlugin plugIn) {
+
+		if(LOG.isDebugEnabled()) {
+			LOG.debug("==> RangerUserStoreProvider(serviceName= " + serviceName  + " serviceType= " + serviceType +").loadUserGroups()");
+		}
+
+		RangerPerfTracer perf = null;
+
+		if(RangerPerfTracer.isPerfTraceEnabled(PERF_POLICYENGINE_INIT_LOG)) {
+			perf = RangerPerfTracer.getPerfTracer(PERF_POLICYENGINE_INIT_LOG, "RangerUserStoreProvider.loadUserGroups(serviceName=" + serviceName + ")");
+			long freeMemory = Runtime.getRuntime().freeMemory();
+			long totalMemory = Runtime.getRuntime().totalMemory();
+			PERF_POLICYENGINE_INIT_LOG.debug("In-Use memory: " + (totalMemory-freeMemory) + ", Free memory:" + freeMemory);
+		}
+
+		try {
+			//load userGroupRoles from ranger admin
+			RangerUserStore userStore = loadUserStoreFromAdmin();
+
+			if (userStore == null) {
+				//if userGroupRoles fetch from ranger Admin Fails, load from cache
+				if (!rangerUserStoreSetInPlugin) {
+					userStore = loadUserStoreFromCache();
+				}
+			}
+
+			if (PERF_POLICYENGINE_INIT_LOG.isDebugEnabled()) {
+				long freeMemory = Runtime.getRuntime().freeMemory();
+				long totalMemory = Runtime.getRuntime().totalMemory();
+				PERF_POLICYENGINE_INIT_LOG.debug("In-Use memory: " + (totalMemory - freeMemory) + ", Free memory:" + freeMemory);
+			}
+
+			if (userStore != null) {
+				plugIn.setUserStore(userStore);
+				rangerUserStoreSetInPlugin = true;
+				setLastActivationTimeInMillis(System.currentTimeMillis());
+				lastKnownUserStoreVersion = userStore.getUserStoreVersion();
+			} else {
+				if (!rangerUserStoreSetInPlugin && !serviceDefSetInPlugin) {
+					plugIn.setUserStore(userStore);
+					serviceDefSetInPlugin = true;
+				}
+			}
+		} catch (RangerServiceNotFoundException snfe) {
+			if (disableCacheIfServiceNotFound) {
+				disableCache();
+				plugIn.setUserStore(null);
+				setLastActivationTimeInMillis(System.currentTimeMillis());
+				lastKnownUserStoreVersion = -1L;
+				serviceDefSetInPlugin = true;
+			}
+		} catch (Exception excp) {
+			LOG.error("Encountered unexpected exception, ignoring..", excp);
+		}
+
+		RangerPerfTracer.log(perf);
+
+		if(LOG.isDebugEnabled()) {
+			LOG.debug("<== RangerUserStoreProvider(serviceName=" + serviceName + ").loadUserGroups()");
+		}
+	}
+
+	private RangerUserStore loadUserStoreFromAdmin() throws RangerServiceNotFoundException {
+
+		if(LOG.isDebugEnabled()) {
+			LOG.debug("==> RangerUserStoreProvider(serviceName=" + serviceName + ").loadUserStoreFromAdmin()");
+		}
+
+		RangerUserStore userStore;
+
+		RangerPerfTracer perf = null;
+
+		if(RangerPerfTracer.isPerfTraceEnabled(PERF_POLICYENGINE_INIT_LOG)) {
+			perf = RangerPerfTracer.getPerfTracer(PERF_POLICYENGINE_INIT_LOG, "RangerUserStoreProvider.loadUserStoreFromAdmin(serviceName=" + serviceName + ")");
+		}
+
+		try {
+			userStore = rangerAdmin.getUserStoreIfUpdated(lastKnownUserStoreVersion, lastActivationTimeInMillis);
+
+			boolean isUpdated = userStore != null;
+
+			if(isUpdated) {
+				long newVersion = userStore.getUserStoreVersion() == null ? -1 : userStore.getUserStoreVersion().longValue();
+				saveToCache(userStore);
+				LOG.info("RangerUserStoreProvider(serviceName=" + serviceName + "): found updated version. lastKnownUserStoreVersion=" + lastKnownUserStoreVersion + "; newVersion=" + newVersion );
+			} else {
+				if(LOG.isDebugEnabled()) {
+					LOG.debug("RangerUserStoreProvider(serviceName=" + serviceName + ").run(): no update found. lastKnownUserStoreVersion=" + lastKnownUserStoreVersion );
+				}
+			}
+		} catch (RangerServiceNotFoundException snfe) {
+			LOG.error("RangerUserStoreProvider(serviceName=" + serviceName + "): failed to find service. Will clean up local cache of userStore (" + lastKnownUserStoreVersion + ")", snfe);
+			throw snfe;
+		} catch (Exception excp) {
+			LOG.error("RangerUserStoreProvider(serviceName=" + serviceName + "): failed to refresh userStore. Will continue to use last known version of userStore (" + "lastKnowRoleVersion= " + lastKnownUserStoreVersion, excp);
+			userStore = null;
+		}
+
+		RangerPerfTracer.log(perf);
+
+		if(LOG.isDebugEnabled()) {
+			LOG.debug("<== RangerUserStoreProvider(serviceName=" + serviceName + " serviceType= " + serviceType + " ).loadUserStoreFromAdmin()");
+		 }
+
+		 return userStore;
+	}
+
+	private RangerUserStore loadUserStoreFromCache() {
+
+		RangerUserStore userStore = null;
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("==> RangerUserStoreProvider(serviceName=" + serviceName + ").loadUserStoreFromCache()");
+		}
+
+		File cacheFile = cacheDir == null ? null : new File(cacheDir + File.separator + cacheFileName);
+
+		if (cacheFile != null && cacheFile.isFile() && cacheFile.canRead()) {
+			Reader reader = null;
+
+			RangerPerfTracer perf = null;
+
+			if (RangerPerfTracer.isPerfTraceEnabled(PERF_POLICYENGINE_INIT_LOG)) {
+				perf = RangerPerfTracer.getPerfTracer(PERF_POLICYENGINE_INIT_LOG, "RangerUserStoreProvider.loadUserStoreFromCache(serviceName=" + serviceName + ")");
+			}
+
+			try {
+				reader = new FileReader(cacheFile);
+
+				userStore = gson.fromJson(reader, RangerUserStore.class);
+
+				if (userStore != null) {
+					if (!StringUtils.equals(serviceName, userStore.getServiceName())) {
+						LOG.warn("ignoring unexpected serviceName '" + userStore.getServiceName() + "' in cache file '" + cacheFile.getAbsolutePath() + "'");
+
+						userStore.setServiceName(serviceName);
+					}
+
+					lastKnownUserStoreVersion = userStore.getUserStoreVersion() == null ? -1 : userStore.getUserStoreVersion().longValue();
+				}
+			} catch (Exception excp) {
+				LOG.error("failed to load userStore from cache file " + cacheFile.getAbsolutePath(), excp);
+			} finally {
+				RangerPerfTracer.log(perf);
+
+				if (reader != null) {
+					try {
+						reader.close();
+					} catch (Exception excp) {
+						LOG.error("error while closing opened cache file " + cacheFile.getAbsolutePath(), excp);
+					}
+				}
+			}
+		} else {
+			userStore = new RangerUserStore();
+			userStore.setServiceName(serviceName);
+			userStore.setUserStoreVersion(-1L);
+			userStore.setUserStoreUpdateTime(new Date());
+			userStore.setUserGroupMapping(new HashMap<String, Set<String>>());
+			saveToCache(userStore);
+		}
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("<== RangerUserStoreProvider(serviceName=" + serviceName + ").RangerUserStoreProvider()");
+		}
+
+		return userStore;
+	}
+
+	public void saveToCache(RangerUserStore userStore) {
+		if(LOG.isDebugEnabled()) {
+			LOG.debug("==> RangerUserStoreProvider(serviceName=" + serviceName + ").saveToCache()");
+		}
+
+		if(userStore != null) {
+			File cacheFile = null;
+			if (cacheDir != null) {
+				// Create the cacheDir if it doesn't already exist
+				File cacheDirTmp = new File(cacheDir);
+				if (cacheDirTmp.exists()) {
+					cacheFile =  new File(cacheDir + File.separator + cacheFileName);
+				} else {
+					try {
+						cacheDirTmp.mkdirs();
+						cacheFile =  new File(cacheDir + File.separator + cacheFileName);
+					} catch (SecurityException ex) {
+						LOG.error("Cannot create cache directory", ex);
+					}
+				}
+			}
+
+			if(cacheFile != null) {
+
+				RangerPerfTracer perf = null;
+
+				if(RangerPerfTracer.isPerfTraceEnabled(PERF_POLICYENGINE_INIT_LOG)) {
+					perf = RangerPerfTracer.getPerfTracer(PERF_POLICYENGINE_INIT_LOG, "RangerUserStoreProvider.saveToCache(serviceName=" + serviceName + ")");
+				}
+
+				Writer writer = null;
+
+				try {
+					writer = new FileWriter(cacheFile);
+
+			        gson.toJson(userStore, writer);
+		        } catch (Exception excp) {
+					LOG.error("failed to save userStore to cache file '" + cacheFile.getAbsolutePath() + "'", excp);
+		        } finally {
+					if(writer != null) {
+						try {
+							writer.close();
+						} catch(Exception excp) {
+							LOG.error("error while closing opened cache file '" + cacheFile.getAbsolutePath() + "'", excp);
+						}
+					}
+				}
+
+				RangerPerfTracer.log(perf);
+			}
+		} else {
+			LOG.info("userStore is null. Nothing to save in cache");
+		}
+
+		if(LOG.isDebugEnabled()) {
+			LOG.debug("<== RangerUserStoreProvider.saveToCache(serviceName=" + serviceName + ")");
+		}
+	}
+
+	private void disableCache() {
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("==> RangerUserStoreProvider.disableCache(serviceName=" + serviceName + ")");
+		}
+
+		File cacheFile = cacheDir == null ? null : new File(cacheDir + File.separator + cacheFileName);
+
+		if(cacheFile != null && cacheFile.isFile() && cacheFile.canRead()) {
+			LOG.warn("Cleaning up local RangerUserStore cache");
+			String renamedCacheFile = cacheFile.getAbsolutePath() + "_" + System.currentTimeMillis();
+			if (!cacheFile.renameTo(new File(renamedCacheFile))) {
+				LOG.error("Failed to move " + cacheFile.getAbsolutePath() + " to " + renamedCacheFile);
+			} else {
+				LOG.warn("Moved " + cacheFile.getAbsolutePath() + " to " + renamedCacheFile);
+			}
+		} else {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("No local RangerRoles cache found. No need to disable it!");
+			}
+		}
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("<== RangerUserStoreProvider.disableCache(serviceName=" + serviceName + ")");
+		}
+	}
+}

--- a/plugin-atlas/src/main/java/org/apache/ranger/authorization/atlas/authorizer/RangerAtlasAuthorizer.java
+++ b/plugin-atlas/src/main/java/org/apache/ranger/authorization/atlas/authorizer/RangerAtlasAuthorizer.java
@@ -64,7 +64,7 @@ public class RangerAtlasAuthorizer implements AtlasAuthorizer {
     }};
 
     private static volatile RangerBasePlugin atlasPlugin = null;
-
+    private static volatile RangerGroupUtil groupUtil = null;
     @Override
     public void init() {
         if (LOG.isDebugEnabled()) {
@@ -85,6 +85,7 @@ public class RangerAtlasAuthorizer implements AtlasAuthorizer {
                     plugin.setResultProcessor(new RangerDefaultAuditHandler(plugin.getConfig()));
 
                     atlasPlugin = plugin;
+                    groupUtil = new RangerGroupUtil(atlasPlugin.getUserStore());
                 }
             }
         }
@@ -377,7 +378,6 @@ public class RangerAtlasAuthorizer implements AtlasAuthorizer {
         if (LOG.isDebugEnabled()) {
             LOG.debug("==> isAccessAllowed(" + request + ")");
         }
-
         boolean ret = false;
 
         try {
@@ -442,12 +442,21 @@ public class RangerAtlasAuthorizer implements AtlasAuthorizer {
 
     private boolean checkAccess(RangerAccessRequestImpl request) {
         boolean          ret    = false;
+        String userName = request.getUser();
         RangerBasePlugin plugin = atlasPlugin;
 
         if (plugin != null) {
+            
+            groupUtil.setUserStore(atlasPlugin.getUserStore());
+            
+            request.setUserGroups(groupUtil.getContainedGroups(userName));
+            
+            LOG.warn("Setting UserGroup for user: "+ userName + " Groups: " + groupUtil.getContainedGroups(userName) );
+            
             RangerAccessResult result = plugin.isAccessAllowed(request);
 
             ret = result != null && result.getIsAllowed();
+
         } else {
             LOG.warn("RangerAtlasPlugin not initialized. Access blocked!!!");
         }
@@ -457,12 +466,24 @@ public class RangerAtlasAuthorizer implements AtlasAuthorizer {
 
     private boolean checkAccess(RangerAccessRequestImpl request, RangerAtlasAuditHandler auditHandler) {
         boolean          ret    = false;
+        
         RangerBasePlugin plugin = atlasPlugin;
+        String userName = request.getUser();
+
+        LOG.warn("Setting UserGroup for user"+ userName + " Groups: " + groupUtil.getContainedGroups(userName));
 
         if (plugin != null) {
+            
+            groupUtil.setUserStore(atlasPlugin.getUserStore());
+            
+            request.setUserGroups(groupUtil.getContainedGroups(userName));
+            
+            LOG.warn("Setting UserGroup for user :"+ userName + " Groups: " + groupUtil.getContainedGroups(userName) );
+            
             RangerAccessResult result = plugin.isAccessAllowed(request, auditHandler);
 
             ret = result != null && result.getIsAllowed();
+        
         } else {
             LOG.warn("RangerAtlasPlugin not initialized. Access blocked!!!");
         }

--- a/plugin-atlas/src/main/java/org/apache/ranger/authorization/atlas/authorizer/RangerGroupUtil.java
+++ b/plugin-atlas/src/main/java/org/apache/ranger/authorization/atlas/authorizer/RangerGroupUtil.java
@@ -1,0 +1,61 @@
+package org.apache.ranger.authorization.atlas.authorizer;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.ranger.plugin.util.RangerUserStore;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class RangerGroupUtil {
+    private long                     UserStoreVersion;
+    private Map<String, Set<String>>       userGroupMapping;
+
+    public  enum  GROUP_FOR {USER}
+
+    public RangerGroupUtil(RangerUserStore userStore) {
+        if (userStore != null) {
+            UserStoreVersion = userStore.getUserStoreVersion();
+            userGroupMapping = userStore.getUserGroupMapping();
+        } else {
+            UserStoreVersion = -1L;
+        }
+    }
+
+    public void setUserStore(RangerUserStore userStore) {
+		this.userGroupMapping = userStore.getUserGroupMapping();
+        this.UserStoreVersion = userStore.getUserStoreVersion();
+    }
+
+    public long getUserStoreVersion() { return UserStoreVersion; }
+
+    public Set<String> getContainedGroups(String userName) {
+        Set<String> data = new LinkedHashSet<String>();   
+        Set<String> tmpData = new LinkedHashSet<String>();   
+        tmpData = userGroupMapping.get(userName);
+        if (tmpData != null){
+           data = tmpData;
+        }
+        return data;
+    }
+  
+}
+
+

--- a/security-admin/src/main/java/org/apache/ranger/biz/XUserMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/XUserMgr.java
@@ -265,7 +265,11 @@ public class XUserMgr extends XUserMgrBase {
 		if(vXPortalUser!=null){
 			assignPermissionToUser(vXPortalUser, true);
 		}
-
+		try {
+			daoManager.getXXGlobalState().onGlobalAppDataChange(RANGER_USER_GROUP_GLOBAL_STATE_NAME);
+		} catch (Exception excp) {
+			logger.error("unable to do onGlobalAppDataChange() failed", excp);
+		}
 		return createdXUser;
 	}
 
@@ -467,6 +471,11 @@ public class XUserMgr extends XUserMgrBase {
 			}
 			assignPermissionToUser(vXPortalUser,true);
 		}
+		try {
+			daoManager.getXXGlobalState().onGlobalAppDataChange(RANGER_USER_GROUP_GLOBAL_STATE_NAME);
+		} catch (Exception excp) {
+			logger.error("unable to do onGlobalAppDataChange() failed", excp);
+		}
 		//update permissions end
 		Collection<String> roleList = new ArrayList<String>();
 		if (xXPortalUser != null) {
@@ -498,7 +507,7 @@ public class XUserMgr extends XUserMgrBase {
 		List<Long> groupUsersToRemove = new ArrayList<Long>();
 		trxLogList.addAll(createOrDelGrpUserWithUpdatedGrpId(vXUser, groupIdList,userId, groupUsersToRemove));
 		xaBizUtil.createTrxLog(trxLogList);
-
+		
 		return vXUser;
 	}
 	private List<XXTrxLog> createOrDelGrpUserWithUpdatedGrpId(VXUser vXUser, Collection<Long> groupIdList,Long userId, List<Long> groupUsersToRemove) {
@@ -740,6 +749,11 @@ public class XUserMgr extends XUserMgrBase {
 		List<XXTrxLog> trxLogList = xGroupService.getTransactionLog(vXGroup,
 				"create");
 		xaBizUtil.createTrxLog(trxLogList);
+		try {
+			daoManager.getXXGlobalState().onGlobalAppDataChange(RANGER_USER_GROUP_GLOBAL_STATE_NAME);
+		} catch (Exception excp) {
+			logger.error("unable to do onGlobalAppDataChange() failed", excp);
+		}
 		return vXGroup;
 	}
 
@@ -2204,6 +2218,11 @@ public class XUserMgr extends XUserMgrBase {
 				xaBizUtil.createTrxLog(xXTrxLogsXXGroup);
 			}
 		}
+		try {
+			daoManager.getXXGlobalState().onGlobalAppDataChange(RANGER_USER_GROUP_GLOBAL_STATE_NAME);
+		} catch (Exception excp) {
+			logger.error("unable to do onGlobalAppDataChange() failed", excp);
+		}
 	}
 
 	private void blockIfZoneGroup(Long grpId) {
@@ -2406,6 +2425,11 @@ public class XUserMgr extends XUserMgrBase {
 				trxLogList=xPortalUserService.getTransactionLog(xPortalUserService.populateViewBean(xXPortalUser), "delete");
 				xaBizUtil.createTrxLog(trxLogList);
 			}
+		}
+		try {
+			daoManager.getXXGlobalState().onGlobalAppDataChange(RANGER_USER_GROUP_GLOBAL_STATE_NAME);
+		} catch (Exception excp) {
+			logger.error("unable to do onGlobalAppDataChange() failed", excp);
 		}
 	}
 

--- a/security-admin/src/main/java/org/apache/ranger/rest/XUserREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/XUserREST.java
@@ -1209,59 +1209,59 @@ public class XUserREST {
 		}
 	}
 
-        @DELETE
-        @Path("/secure/users/{userName}")
-        @Produces({ "application/xml", "application/json" })
-        @PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
-        public void deleteSingleUserByUserName(@Context HttpServletRequest request, @PathParam("userName") String userName) {
-                String forceDeleteStr = request.getParameter("forceDelete");
-                boolean forceDelete = false;
-                if (StringUtils.isNotEmpty(forceDeleteStr) && "true".equalsIgnoreCase(forceDeleteStr)) {
-                        forceDelete = true;
-                }
+	@DELETE
+	@Path("/secure/users/{userName}")
+	@Produces({ "application/xml", "application/json" })
+	@PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
+	public void deleteSingleUserByUserName(@Context HttpServletRequest request, @PathParam("userName") String userName) {
+			String forceDeleteStr = request.getParameter("forceDelete");
+			boolean forceDelete = false;
+			if (StringUtils.isNotEmpty(forceDeleteStr) && "true".equalsIgnoreCase(forceDeleteStr)) {
+					forceDelete = true;
+			}
 
-                if (StringUtils.isNotEmpty(userName)) {
-                        VXUser vxUser = xUserService.getXUserByUserName(userName);
-                        xUserMgr.deleteXUser(vxUser.getId(), forceDelete);
-                }
-        }
+			if (StringUtils.isNotEmpty(userName)) {
+					VXUser vxUser = xUserService.getXUserByUserName(userName);
+					xUserMgr.deleteXUser(vxUser.getId(), forceDelete);
+			}
+	}
 
-        @DELETE
-        @Path("/secure/groups/{groupName}")
-        @Produces({ "application/xml", "application/json" })
-        @PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
-        public void deleteSingleGroupByGroupName(@Context HttpServletRequest request, @PathParam("groupName") String groupName) {
-                String forceDeleteStr = request.getParameter("forceDelete");
-                boolean forceDelete = false;
-                if (StringUtils.isNotEmpty(forceDeleteStr) && "true".equalsIgnoreCase(forceDeleteStr)) {
-                        forceDelete = true;
-                }
-                if (StringUtils.isNotEmpty(groupName)) {
-                        VXGroup vxGroup = xGroupService.getGroupByGroupName(groupName.trim());
-                        xUserMgr.deleteXGroup(vxGroup.getId(), forceDelete);
-                }
-        }
+	@DELETE
+	@Path("/secure/groups/{groupName}")
+	@Produces({ "application/xml", "application/json" })
+	@PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
+	public void deleteSingleGroupByGroupName(@Context HttpServletRequest request, @PathParam("groupName") String groupName) {
+			String forceDeleteStr = request.getParameter("forceDelete");
+			boolean forceDelete = false;
+			if (StringUtils.isNotEmpty(forceDeleteStr) && "true".equalsIgnoreCase(forceDeleteStr)) {
+					forceDelete = true;
+			}
+			if (StringUtils.isNotEmpty(groupName)) {
+					VXGroup vxGroup = xGroupService.getGroupByGroupName(groupName.trim());
+					xUserMgr.deleteXGroup(vxGroup.getId(), forceDelete);
+			}
+	}
 
-        @DELETE
-        @Path("/secure/users/id/{userId}")
-        @Produces({ "application/xml", "application/json" })
-        @PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
-        public void deleteSingleUserByUserId(@Context HttpServletRequest request, @PathParam("userId") Long userId) {
-                String forceDeleteStr = request.getParameter("forceDelete");
-                boolean forceDelete = false;
-                if (StringUtils.isNotEmpty(forceDeleteStr) && "true".equalsIgnoreCase(forceDeleteStr)) {
-                        forceDelete = true;
-                }
-                if (userId != null) {
-                        xUserMgr.deleteXUser(userId, forceDelete);
-                }
-        }
+	@DELETE
+	@Path("/secure/users/id/{userId}")
+	@Produces({ "application/xml", "application/json" })
+	@PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
+	public void deleteSingleUserByUserId(@Context HttpServletRequest request, @PathParam("userId") Long userId) {
+			String forceDeleteStr = request.getParameter("forceDelete");
+			boolean forceDelete = false;
+			if (StringUtils.isNotEmpty(forceDeleteStr) && "true".equalsIgnoreCase(forceDeleteStr)) {
+					forceDelete = true;
+			}
+			if (userId != null) {
+					xUserMgr.deleteXUser(userId, forceDelete);
+			}
+	}
 
-        @DELETE
-        @Path("/secure/groups/id/{groupId}")
-        @Produces({ "application/xml", "application/json" })
-        @PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
-        public void deleteSingleGroupByGroupId(@Context HttpServletRequest request, @PathParam("groupId") Long groupId) {
+	@DELETE
+	@Path("/secure/groups/id/{groupId}")
+	@Produces({ "application/xml", "application/json" })
+	@PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
+	public void deleteSingleGroupByGroupId(@Context HttpServletRequest request, @PathParam("groupId") Long groupId) {
                 String forceDeleteStr = request.getParameter("forceDelete");
                 boolean forceDelete = false;
                 if (StringUtils.isNotEmpty(forceDeleteStr) && "true".equalsIgnoreCase(forceDeleteStr)) {
@@ -1355,6 +1355,72 @@ public class XUserREST {
 
 		if (logger.isDebugEnabled()) {
 			logger.debug("<== XUserREST.getSecureRangerUserStoreIfUpdated(" + serviceName + ", " + lastKnownUserStoreVersion + ", " + lastActivationTime + ")" + ret);
+		}
+		return ret;
+	}
+
+	@GET
+	@Path("/download/{serviceName}")
+	@Produces({ "application/xml", "application/json" })
+	public RangerUserStore getRangerUserStoreIfUpdated(@PathParam("serviceName") String serviceName,
+															 @QueryParam("lastKnownUserStoreVersion") Long lastKnownUserStoreVersion,
+															 @DefaultValue("0") @QueryParam("lastActivationTime") Long lastActivationTime,
+															 @QueryParam("pluginId") String pluginId,
+															 @DefaultValue("") @QueryParam("clusterName") String clusterName,
+															 @DefaultValue("") @QueryParam(RangerRESTUtils.REST_PARAM_CAPABILITIES) String pluginCapabilities,
+															 @Context HttpServletRequest request) throws Exception {
+		if (logger.isDebugEnabled()) {
+			logger.debug("==> XUserREST.getRangerUserStoreIfUpdated("
+					+ serviceName + ", " + lastKnownUserStoreVersion + ", " + lastActivationTime + ")");
+		}
+		RangerUserStore ret = null;
+		int     httpCode          = HttpServletResponse.SC_OK;
+		boolean isValid           = false;
+		String  logMsg            = null;
+		Long    downloadedVersion = null;
+
+		try {
+			XXService xService = rangerDaoManager.getXXService().findByName(serviceName);
+			if (xService != null) {
+				isValid = true;
+			}
+			if (isValid) {
+				if (lastKnownUserStoreVersion == null) {
+					lastKnownUserStoreVersion = Long.valueOf(-1);
+				}
+				try {
+					RangerUserStore rangerUserStore = xUserMgr.getRangerUserStore(lastKnownUserStoreVersion);
+					if (rangerUserStore == null) {
+						downloadedVersion = lastKnownUserStoreVersion;
+						httpCode = HttpServletResponse.SC_NOT_MODIFIED;
+						logMsg = "No change since last update";
+					} else {
+						downloadedVersion = rangerUserStore.getUserStoreVersion();
+						ret = rangerUserStore;
+						httpCode = HttpServletResponse.SC_OK;
+						logMsg = "Returning RangerUserStore =>" + (ret.toString());
+					}
+				} catch (Throwable excp) {
+					logger.error("getRangerUserStoreIfUpdated(" + serviceName + ", " + lastKnownUserStoreVersion + ") failed", excp);
+					httpCode = HttpServletResponse.SC_BAD_REQUEST;
+					logMsg = excp.getMessage();
+				}
+			}
+		} catch (Throwable excp) {
+			logger.error("getRangerUserStoreIfUpdated(" + serviceName + ", " + lastKnownUserStoreVersion + ", " + lastActivationTime + ") failed", excp);
+			httpCode = HttpServletResponse.SC_BAD_REQUEST;
+			logMsg = excp.getMessage();
+		}
+
+		assetMgr.createPluginInfo(serviceName, pluginId, request, RangerPluginInfo.ENTITY_TYPE_USERSTORE, downloadedVersion, lastKnownUserStoreVersion, lastActivationTime, httpCode, clusterName, pluginCapabilities);
+
+		if (httpCode != HttpServletResponse.SC_OK) {
+			boolean logError = httpCode != HttpServletResponse.SC_NOT_MODIFIED;
+			throw restErrorUtil.createRESTException(httpCode, logMsg, logError);
+		}
+
+		if (logger.isDebugEnabled()) {
+			logger.debug("<== XUserREST.getRangerUserStoreIfUpdated(" + serviceName + ", " + lastKnownUserStoreVersion + ", " + lastActivationTime + ")" + ret);
 		}
 		return ret;
 	}

--- a/security-admin/src/main/resources/conf.dist/security-applicationContext.xml
+++ b/security-admin/src/main/resources/conf.dist/security-applicationContext.xml
@@ -46,6 +46,8 @@ http://www.springframework.org/schema/security/spring-security-oauth2-2.0.xsd">
 	<security:http pattern="/service/tags/download/*" security="none"/>
 	<security:http pattern="/service/roles/download/*" security="none"/>
 	<security:http pattern="/service/metrics/status" security="none" />
+	<security:http pattern="/service/xusers/download/*" security="none" />
+
 	<security:http disable-url-rewriting="true" use-expressions="true" create-session="always" entry-point-ref="authenticationProcessingFilterEntryPoint">
 		<csrf disabled="true"/>
 		<security:headers>


### PR DESCRIPTION
## Change description

- XUserRest.java - Added new API (`/service/xusers/download/`) for downloading UserStore if no cred is used which is similar to Roles Download.
- Updated RangerAdminRESTClient.java to with latest changes in `getUserStoreIfUpdated` to support both secure/without cred API's
- Updated PolicyRefresher.java to include RangerUserStoreProvider for Download/Updating UserStore Cache.
- Added RangerGroupUtil.java in RangerAtlasAuthorizer(Atlas Plugin) - it will help to retrieve Groups names for a user from UserStore in Cache. 
- Updated XUserMgr.java to do state change on Create/Update/Delete API call for Groups/Users.

## Type of change
- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
