### PR TITLE
META-3185 : Fix accessor, deny user not returned, when only deny Tag policy is present

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/authorization/hadoop/config/RangerConfiguration.java
+++ b/agents-common/src/main/java/org/apache/ranger/authorization/hadoop/config/RangerConfiguration.java
@@ -54,13 +54,13 @@ public class RangerConfiguration extends Configuration {
 				addResource(fUrl);
 				ret = true;
 			} catch (Exception e) {
-				LOG.error("Unable to load the resource name [" + aResourceName + "]. Ignoring the resource:" + fUrl);
+				LOG.warn("Unable to load the resource name [" + aResourceName + "]. Ignoring the resource:" + fUrl);
 				if (LOG.isDebugEnabled()) {
 					LOG.debug("Resource loading failed for " + fUrl, e);
 				}
 			}
 		} else {
-			LOG.error("addResourceIfReadable(" + aResourceName + "): couldn't find resource file location");
+			LOG.warn("addResourceIfReadable(" + aResourceName + "): couldn't find resource file location");
 		}
 
 		if(LOG.isDebugEnabled()) {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerDefaultPolicyEvaluator.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/policyevaluator/RangerDefaultPolicyEvaluator.java
@@ -1267,14 +1267,17 @@ public class RangerDefaultPolicyEvaluator extends RangerAbstractPolicyEvaluator 
 		return ret;
 	}
 
+
 	protected RangerPolicyItemEvaluator getMatchingPolicyItemForAccessPolicyForSpecificAccess(RangerAccessRequest request, RangerAccessResult result) {
-		RangerPolicyItemEvaluator ret = getMatchingPolicyItem(request, result, denyEvaluators, denyExceptionEvaluators);
-
-		if(request.isAccessorsRequested() || (ret == null && !result.getIsAccessDetermined())) { // a deny policy could have set isAllowed=true, but in such case it wouldn't set isAccessDetermined=true
-			ret = getMatchingPolicyItem(request, result, allowEvaluators, allowExceptionEvaluators);
+		RangerPolicyItemEvaluator denyEvaluator = getMatchingPolicyItem(request, result, denyEvaluators, denyExceptionEvaluators);
+		RangerPolicyItemEvaluator evaluator = denyEvaluator;
+		if (request.isAccessorsRequested() || (denyEvaluator == null && !result.getIsAccessDetermined())) { // a deny policy could have set isAllowed=true, but in such case it wouldn't set isAccessDetermined=true
+			RangerPolicyItemEvaluator allowEvaluator = getMatchingPolicyItem(request, result, allowEvaluators, allowExceptionEvaluators);
+			if (allowEvaluator != null && denyEvaluator == null) {
+				evaluator = allowEvaluator;
+			}
 		}
-
-		return ret;
+		return evaluator;
 	}
 
 	protected <T extends RangerPolicyItemEvaluator> T getMatchingPolicyItem(RangerAccessRequest request, RangerAccessResult result,

--- a/plugin-atlas/src/main/java/org/apache/ranger/authorization/atlas/authorizer/RangerAtlasAuthorizer.java
+++ b/plugin-atlas/src/main/java/org/apache/ranger/authorization/atlas/authorizer/RangerAtlasAuthorizer.java
@@ -734,11 +734,13 @@ public class RangerAtlasAuthorizer implements AtlasAuthorizer {
         if (plugin != null) {
             
             groupUtil.setUserStore(atlasPlugin.getUserStore());
-            
+
             request.setUserGroups(groupUtil.getContainedGroups(userName));
-            
-            LOG.warn("Setting UserGroup for user: "+ userName + " Groups: " + groupUtil.getContainedGroups(userName) );
-            
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Setting UserGroup for user: " + userName + " Groups: " + groupUtil.getContainedGroups(userName));
+            }
+
             RangerAccessResult result = plugin.isAccessAllowed(request);
 
             ret = result != null && result.getIsAllowed();


### PR DESCRIPTION

## Change description
META-3185 : Fix accessor, deny user not returned, when only deny Tag policy is present
https://linear.app/atlanproduct/issue/META-3185
> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
